### PR TITLE
quick-start: workaround github pages resolving liquid tags

### DIFF
--- a/src/components/util.js
+++ b/src/components/util.js
@@ -52,7 +52,7 @@ export function parse(markdown, cb) {
   renderer.heading = (text, level) => `<h${level} id="${hrefLink(text)}" class="uk-h${level > 1 ? level + 1 : level} tm-heading-fragment"><a href="#${hrefLink(text)}">${text}</a></h${level}>`;
 
   return marked(markdown, { renderer }, (err, content) => {
-    content = content.replace(/{%latestVersion%}/g, jk.latestVersion);
+    content = content.replace(/%%latestVersion%%/g, jk.latestVersion);
 
     if (cb) {
       cb.apply(this, [err, content]);

--- a/static/docs/quick-start.md
+++ b/static/docs/quick-start.md
@@ -20,7 +20,7 @@ To install `jk`, download the [latest binary][latest] for your operating
 system. For example, to install `jk` on MacOS, run:
 
 ```shell
-curl -Lo jk https://github.com/jkcfg/jk/releases/download/{%latestVersion%}/jk-darwin-amd64
+curl -Lo jk https://github.com/jkcfg/jk/releases/download/%%latestVersion%%/jk-darwin-amd64
 chmod +x jk
 sudo mv jk /usr/local/bin/
 ```
@@ -29,7 +29,7 @@ Check `jk` is correctly installed with:
 
 ```console
 $ jk version
-version: {%latestVersion%}
+version: %%latestVersion%%
 ```
 
 We currently provide binary releases for MacOS X and Linux.


### PR DESCRIPTION
Using {% %} seems to clash with the github pages jekyll templating. Use %%
instead.